### PR TITLE
da cycling index catch

### DIFF
--- a/src/libs/pestpp_common/DataAssimilator.cpp
+++ b/src/libs/pestpp_common/DataAssimilator.cpp
@@ -1271,20 +1271,20 @@ void DataAssimilator::initialize(int _icycle)
 	message(2, "checking for denormal values in pe");
 	if (icycle == 0)
 		pe.check_for_normal("initial transformed parameter ensemble");
-	if (false) // we need to save the forecast matrix, not the initial matrix
+	//if (false) // we need to save the forecast matrix, not the initial matrix
+	//{
+	ss.str("");
+	if (pest_scenario.get_pestpp_options().get_ies_save_binary())
 	{
-		ss.str("");
-		if (pest_scenario.get_pestpp_options().get_ies_save_binary())
-		{
-			ss << file_manager.get_base_filename() << ".0.par.jcb";
-			pe.to_binary(ss.str());
-		}
-		else
-		{
-			ss << file_manager.get_base_filename() << "_cycle_" << icycle << ".par.csv";
-			pe.to_csv(ss.str());
-		}
+		ss << file_manager.get_base_filename() << "_cycle_" << icycle << ".par.jcb";
+		pe.to_binary(ss.str());
 	}
+	else
+	{
+		ss << file_manager.get_base_filename() << "_cycle_" << icycle << ".par.csv";
+		pe.to_csv(ss.str());
+	}
+	//}
 	message(1, "saved initial parameter ensemble to ", ss.str());
 	message(2, "checking for denormal values in base oe");
 	oe.check_for_normal("base observation ensemble");

--- a/src/libs/pestpp_common/Pest.cpp
+++ b/src/libs/pestpp_common/Pest.cpp
@@ -2234,18 +2234,6 @@ void Pest::assign_da_cycles(ofstream &f_rec)
 				ss << m << ",";
 			throw_control_file_error(f_rec, ss.str());
 		}
-		vector<int> cycle_vec;
-		for (auto pp : obs_cycle_map)
-		{
-			cycle_vec.push_back(pp.second);
-		}
-		//catches non-zero-indexing cycle input
-		if (std::all_of(cycle_vec.begin(), cycle_vec.end(), [](int i) {return i != 0; }))
-		{
-			ss.str("");
-			ss << "a cycle of zero does not exist; cycling needs to start at zero for initialization...";
-			throw_control_file_error(f_rec, ss.str());
-		}
 		for (auto oc : obs_cycle_map)
 		{
 			observation_info.get_observation_rec_ptr_4_mod(oc.first)->cycle = oc.second;
@@ -2560,7 +2548,7 @@ void Pest::child_pest_update(int icycle)
 	//this.check_inputs();
 }
 
-vector<int> Pest::get_assim_cycles()
+vector<int> Pest::get_assim_cycles(ofstream& f_rec)
 {
 	int curr_cycle;
 	vector<int> cycles_ordered_list, unique_cycles;
@@ -2584,6 +2572,14 @@ vector<int> Pest::get_assim_cycles()
 		}
 	}
 	sort(unique_cycles.begin(), unique_cycles.end());
+	stringstream ss;
+	//to catch common non-zero-indexing
+	if (unique_cycles.front() != 0)  //recall a cycle of -1 is just a flag
+	{
+		ss.str("");
+		ss << "a cycle with index of zero does not exist; cycling needs to start at zero for initialization...";
+		throw_control_file_error(f_rec, ss.str());;
+	}
 	return unique_cycles;
 	
 

--- a/src/libs/pestpp_common/Pest.cpp
+++ b/src/libs/pestpp_common/Pest.cpp
@@ -2234,6 +2234,18 @@ void Pest::assign_da_cycles(ofstream &f_rec)
 				ss << m << ",";
 			throw_control_file_error(f_rec, ss.str());
 		}
+		vector<int> cycle_vec;
+		for (auto pp : obs_cycle_map)
+		{
+			cycle_vec.push_back(pp.second);
+		}
+		//catches non-zero-indexing cycle input
+		if (std::all_of(cycle_vec.begin(), cycle_vec.end(), [](int i) {return i != 0; }))
+		{
+			ss.str("");
+			ss << "a cycle of zero does not exist; cycling needs to start at zero for initialization...";
+			throw_control_file_error(f_rec, ss.str());
+		}
 		for (auto oc : obs_cycle_map)
 		{
 			observation_info.get_observation_rec_ptr_4_mod(oc.first)->cycle = oc.second;

--- a/src/libs/pestpp_common/Pest.h
+++ b/src/libs/pestpp_common/Pest.h
@@ -91,7 +91,7 @@ public:
 
 	Pest &get_child_pest(int icycle);
 	void child_pest_update(int icycle);
-	vector<int> get_assim_cycles();
+	vector<int> get_assim_cycles(ofstream& f_rec);
 	void assign_da_cycles(ofstream& f_rec);
 	vector<pair<string, int>> extract_cycle_numbers2(ofstream& f_rec, string section_name, vector<string> possible_name_cols);
 	map<string, double> get_ext_file_double_map(const string& section_name, const string& col_name);

--- a/src/programs/pestpp-da/pestpp-da.cpp
+++ b/src/programs/pestpp-da/pestpp-da.cpp
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
 		
 		vector<int> assimilation_cycles;
 		pest_scenario.assign_da_cycles(fout_rec); 
-		assimilation_cycles = pest_scenario.get_assim_cycles();
+		assimilation_cycles = pest_scenario.get_assim_cycles(fout_rec);
 		ParameterEnsemble curr_pe;
 
 		// loop over assimilation cycles

--- a/src/programs/pestpp-da/pestpp-da.cpp
+++ b/src/programs/pestpp-da/pestpp-da.cpp
@@ -547,7 +547,7 @@ int main(int argc, char* argv[])
 
 			fout_rec.close();			
 		} // end cycle loop
-		cout << endl << endl << "pestpp-ies analysis complete..." << endl;
+		cout << endl << endl << "pestpp-da analysis complete..." << endl;
 		cout << flush;
 		return 0;
 #ifndef _DEBUG


### PR DESCRIPTION
@aymanalz @jtwhite79 this is a small PR to handle cycle index issues, particularly cycling not starting at zero. This, as a result of the condition on line 525 of `pestpp-da.cpp`, would otherwise cause `initialize()` in the first cycle to skip `pe.draw()` where no ensemble is parsed, and ultimately throw a far-downstream `get_eigen()` error. 